### PR TITLE
refactor: Split function exit_with_free_all() into several sub functions (#5) (#24)

### DIFF
--- a/includes/cub3d.h
+++ b/includes/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/28 11:41:26 by sokim             #+#    #+#             */
-/*   Updated: 2022/08/30 16:23:46 by sokim            ###   ########.fr       */
+/*   Updated: 2022/08/30 16:43:03 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,6 +77,7 @@ int	save_floor_ceiling_color(t_info *info, char *line);
 /*
  * Exit functions
  */
+void	free_all(char *line, t_info *info);
 void	exit_with_free_all(char *msg, char *line, t_info *info);
 
 #endif

--- a/srcs/exit/exit.c
+++ b/srcs/exit/exit.c
@@ -6,17 +6,25 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/28 15:55:11 by sokim             #+#    #+#             */
-/*   Updated: 2022/08/30 12:41:07 by sokim            ###   ########.fr       */
+/*   Updated: 2022/08/30 16:42:39 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub3d.h"
 
-void	exit_with_free_all(char *msg, char *line, t_info *info)
+static void	free_line(char *line)
+{
+	if (line)
+		free(line);
+}
+
+static void	free_info(t_info *info)
 {
 	int	i;
 
-	if (info && info->map.map)
+	if (!info)
+		return ;
+	if (info->map.map)
 	{
 		i = 0;
 		while (info->map.map[i])
@@ -26,18 +34,26 @@ void	exit_with_free_all(char *msg, char *line, t_info *info)
 		}
 		free(info->map.map);
 	}
-	if (info && info->map.tmp)
+	if (info->map.tmp)
 		free(info->map.tmp);
-	if (line)
-		free(line);
-	if (info && info->fd)
+	if (info->fd)
 		close(info->fd);
-	i = 0;
-	while (info && info->map.tex_files && info->map.tex_files[i])
+	while (info->map.tex_files && info->map.tex_files[i])
 	{
 		free(info->map.tex_files[i]);
 		i++;
 	}
+}
+
+void	free_all(char *line, t_info *info)
+{
+	free_line(line);
+	free_info(info);
+}
+
+void	exit_with_free_all(char *msg, char *line, t_info *info)
+{
+	free_all(line, info);
 	ft_putendl_fd("Error", 2);
 	ft_putendl_fd(msg, 2);
 	exit(EXIT_FAILURE);


### PR DESCRIPTION
- exit_with_free_all() 함수 분리
    - info 와 line 을 전부 메모리 해제하는 free_all()
    - static 함수 free_info()
    - static 함수 free_line()