### PR TITLE
feat: Add 0.5 to player's initial position (#40)

### DIFF
--- a/includes/macro.h
+++ b/includes/macro.h
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/30 16:54:10 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/02 14:51:25 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/04 12:08:45 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,5 +53,10 @@
 # define KEY_LEFT 123
 # define KEY_RIGHT 124
 # define BUTTON_CLOSE 17
+
+/*
+ * Player movement
+ */
+# define PLAYER_SPEED 0.6
 
 #endif

--- a/includes/struct.h
+++ b/includes/struct.h
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/30 16:53:35 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/02 18:19:40 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/04 12:17:46 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,12 +19,19 @@ typedef struct s_vector
 	double		y;
 }	t_vector;
 
+typedef struct s_key
+{
+	int			wasd[4];
+	double		arrow;
+}	t_key;
+
 typedef struct s_player
 {
 	char		direction;
 	t_vector	pos;
 	t_vector	dir;
 	t_vector	plane;
+	t_key		key;
 }	t_player;
 
 typedef struct s_map

--- a/srcs/map/map.c
+++ b/srcs/map/map.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/28 15:54:19 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/02 18:28:07 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/04 11:44:52 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,8 +25,8 @@ static int	count_map_lines(char **map)
 static void	set_player_info(t_info *info, char direction, int i, int j)
 {
 	info->player->direction = direction;
-	info->player->pos.x = j;
-	info->player->pos.y = i;
+	info->player->pos.x = j + 0.5;
+	info->player->pos.y = i + 0.5;
 	rotate_player(info->player, direction);
 	info->map->num_of_player++;
 }

--- a/srcs/mlx/keyhook.c
+++ b/srcs/mlx/keyhook.c
@@ -6,17 +6,32 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/02 14:30:59 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/02 15:39:58 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/04 12:18:32 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub3d.h"
 
-static int	move_player_position(int keycode, t_info *info)
+static int	move_player_position(int keycode, t_info *info, int value)
 {
-	(void) keycode;
-	(void) info;
-	return (1);
+	if (keycode == KEY_D)
+		info->player->key.wasd[FT_EAST] = value;
+	else if (keycode == KEY_A)
+		info->player->key.wasd[FT_WEST] = value;
+	else if (keycode == KEY_S)
+		info->player->key.wasd[FT_SOUTH] = value;
+	else if (keycode == KEY_W)
+		info->player->key.wasd[FT_NORTH] = value;
+	return (FT_TRUE);
+}
+
+static int	move_direction_vector(int keycode, t_info *info)
+{
+	if (keycode == KEY_LEFT)
+		info->player->key.arrow = -PLAYER_SPEED;
+	else if (keycode == KEY_RIGHT)
+		info->player->key.arrow = PLAYER_SPEED;
+	return (FT_TRUE);
 }
 
 int	key_down(int keycode, t_info *info)
@@ -24,13 +39,19 @@ int	key_down(int keycode, t_info *info)
 	if (keycode == KEY_ESC)
 		exit_with_button_close(info);
 	else if (keycode == KEY_D || keycode == KEY_A || keycode == KEY_S || keycode == KEY_W)
-		return (move_player_position(keycode, info));
-	return (1);
+		return (move_player_position(keycode, info, FT_TRUE));
+	else if (keycode == KEY_LEFT || keycode == KEY_RIGHT)
+		return (move_direction_vector(keycode, info));
+	return (FT_TRUE);
 }
 
 int	key_up(int keycode, t_info *info)
 {
-	(void) keycode;
-	(void) info;
-	return (1);
+	if (keycode == KEY_D || keycode == KEY_A || keycode == KEY_S || keycode == KEY_W)
+		return (move_player_position(keycode, info, FT_FALSE));
+	else if (keycode == KEY_LEFT)
+		info->player->key.arrow = 0;
+	else if (keycode == KEY_RIGHT)
+		info->player->key.arrow = 0;
+	return (FT_TRUE);
 }


### PR DESCRIPTION
- 플레이어 스폰 위치를 맵 데이터 상의 위치로부터 +0.5
- w, a, s, d, <-, -> 키를 누르고 떼었을 때 호출되는 함수 구현 