### PR TITLE
feat: Implement draw_line() and fix error (#45)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@
 #    By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/08/28 11:32:01 by sokim             #+#    #+#              #
-#    Updated: 2022/09/05 15:51:43 by sokim            ###   ########.fr        #
+#    Updated: 2022/09/05 16:26:48 by sokim            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 NAME = cub3d
 
 CC = gcc
-CFLAGS = 
+CFLAGS = -Wall -Wextra -Werror
 
 SRCS = srcs/main.c \
 		srcs/init/info.c \

--- a/maps/map.cub
+++ b/maps/map.cub
@@ -3,8 +3,8 @@ SO ./textures/green.xpm
 WE ./textures/cream.xpm
 EA ./textures/grey.xpm
 
-F 220,100,0
-C 225,30,0
+F 0,255,0
+C 0,0,255
 
         1111111111111111111111111
         1000000000110000000000001

--- a/srcs/dda/hit.c
+++ b/srcs/dda/hit.c
@@ -6,24 +6,11 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/05 14:21:22 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/05 14:37:33 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/05 16:25:36 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub3d.h"
-
-static bool	is_edge(char **map, t_dda *dda, int x, int y)
-{
-	if (dda->ray_dir_x < 0 && dda->ray_dir_y < 0)
-		return (map[y + 1][x] == '1' && map[y][x + 1] == '1');
-	else if (dda->ray_dir_x > 0 && dda->ray_dir_y < 0)
-		return (map[y + 1][x] == '1' && map[y][x - 1] == '1');
-	else if (dda->ray_dir_x < 0 && dda->ray_dir_y > 0)
-		return (map[y - 1][x] == '1' && map[y][x + 1] == '1');
-	else if (dda->ray_dir_x > 0 && dda->ray_dir_y > 0)
-		return (map[y - 1][x] == '1' && map[y][x - 1] == '1');
-	return (FT_TRUE);
-}
 
 void	find_wall_hit(t_dda *dda, t_info *info)
 {
@@ -41,9 +28,10 @@ void	find_wall_hit(t_dda *dda, t_info *info)
 			dda->map_y += dda->step_y;
 			dda->hit_side = HIT_Y;
 		}
-		if (info->map->map[dda->map_y][dda->map_x] == '1')
-			dda->is_hit = FT_TRUE;
-		if (is_edge(info->map->map, dda, dda->map_x, dda->map_y))
+		if (dda->map_x < 0 || dda->map_x >= info->map->width
+			|| dda->map_y < 0 || dda->map_y >= info->map->height)
+			return ;
+		else if (info->map->map[dda->map_y][dda->map_x] == '1')
 			dda->is_hit = FT_TRUE;
 	}
 }

--- a/srcs/mlx/draw.c
+++ b/srcs/mlx/draw.c
@@ -6,23 +6,11 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/04 16:25:08 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/05 15:51:20 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/05 16:17:21 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub3d.h"
-
-static void	verLine(t_info *info, int x, int y1, int y2, int color)
-{
-	int	y;
-
-	y = y1;
-	while (y <= y2)
-	{
-		mlx_pixel_put(info->mlx, info->window, x, y, color);
-		y++;
-	}
-}
 
 static void	draw_line(t_info *info, t_dda *dda, int w)
 {
@@ -31,8 +19,13 @@ static void	draw_line(t_info *info, t_dda *dda, int w)
 	int	color;
 
 	calc_line_height(&start, &end, dda);
-	color = 13145800;
-	verLine(info, w, start, end, color);
+	color = (200 << 16) | (150 << 8) | (200);
+	while (start < end)
+	{
+		*(unsigned int *)(info->img->data + start * info->img->line_length + w * info->img->bpp / 8) \
+			= color;
+		start++;
+	}
 }
 
 static void	draw_wall(t_info *info)
@@ -47,6 +40,7 @@ static void	draw_wall(t_info *info)
 		find_wall_hit(&dda, info);
 		set_perp_wall_dist(&dda, info->player);
 		draw_line(info, &dda, w);
+		w++;
 	}
 }
 
@@ -77,6 +71,6 @@ void	draw_frame(t_info *info)
 {
 	set_player_position(info);
 	draw_ceiling_floor(info->img, info->map);
-	// draw_wall(info);
+	draw_wall(info);
 	mlx_put_image_to_window(info->mlx, info->window, info->img->img, 0, 0);
 }


### PR DESCRIPTION
- 화면 가운데에 벽과 동일한 색상의 선이 화면을 가로질러 그려지는 문제 해결
    -  find_wall_hit() 에서 is_edge() 함수로 벽과 벽 사이를 광선이 통과하지 못하도록 검사하는 부분에서 벽 충돌로 판정이 나서 생긴 문제
    -  따라서 is_edge() 를 제거한 대신 맵 상에서 벽인지 판단하기 이전에 인덱스가 맵 밖으로 나갔는지 검사 추가
- draw_line() 함수 구현
    - draw_ceiling_floor() 와 같은 방식으로 구현
    - 아직은 텍스처를 적용하지 않았으므로 임의의 컬러를 지정하여 벽을 그림