### PR TITLE
fix: Fix bug which player did not move or rotate even if key was pressed

### DIFF
--- a/includes/cub3d.h
+++ b/includes/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/28 11:41:26 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/05 15:46:04 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/06 11:30:51 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,7 +68,7 @@ void	set_player_position(t_info *info);
 /*
  * Drawing functions
  */
-void	draw_frame(t_info *info);
+int		draw_frame(t_info *info);
 
 /*
  * DDA functions

--- a/includes/macro.h
+++ b/includes/macro.h
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/30 16:54:10 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/05 14:26:48 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/06 11:56:49 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,8 @@
 /*
  * Player movement
  */
-# define PLAYER_SPEED 0.6
+# define PLAYER_MOVE_SPEED 0.06
+# define PLAYER_ROTATE_SPEED 5
 
 /*
  * DDA

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/28 11:35:09 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/04 17:58:03 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/06 11:29:50 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,10 +30,10 @@ int	main(int argc, char **argv)
 		exit_with_free_all("Invalid number of arguments.", NULL, &info);
 	init_info(&info);
 	open_file_name(argv[1], &info);
-	draw_frame(&info);
 	mlx_hook(info.window, KEY_PRESS, 0, &key_down, &info);
 	mlx_hook(info.window, KEY_RELEASE, 0, &key_up, &info);
 	mlx_hook(info.window, BUTTON_CLOSE, 0, &exit_with_button_close, &info);
+	mlx_loop_hook(info.mlx, draw_frame, &info);
 	mlx_loop(info.mlx);
 	return (0);
 }

--- a/srcs/map/player.c
+++ b/srcs/map/player.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/04 13:59:45 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/04 15:12:47 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/06 11:58:02 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,8 @@
 
 static bool	is_edge(char **map, t_player *player, t_vector *next)
 {
-	int	x;
-	int	y;
+	int			x;
+	int			y;
 
 	x = (int)next->x;
 	y = (int)next->y;
@@ -27,7 +27,7 @@ static bool	is_edge(char **map, t_player *player, t_vector *next)
 		return (map[y - 1][x] == '1' && map[y][x + 1] == '1');
 	else if (player->dir.x > 0 && player->dir.y > 0)
 		return (map[y - 1][x] == '1' && map[y][x - 1] == '1');
-	return (FT_TRUE);
+	return (FT_FALSE);
 }
 
 static bool	is_available_to_move(t_map *map, t_player *player, t_vector *next)
@@ -62,23 +62,23 @@ static void	get_amount_to_move(t_info *info, t_vector *delta)
 {
 	if (info->player->key.wasd[FT_EAST])
 	{
-		delta->x += info->player->plane.x * PLAYER_SPEED;
-		delta->y += info->player->plane.y * PLAYER_SPEED;
+		delta->x += info->player->plane.x * PLAYER_MOVE_SPEED;
+		delta->y += info->player->plane.y * PLAYER_MOVE_SPEED;
 	}
 	if (info->player->key.wasd[FT_WEST])
 	{
-		delta->x += info->player->plane.x * PLAYER_SPEED * -1;
-		delta->y += info->player->plane.y * PLAYER_SPEED * -1;
+		delta->x += info->player->plane.x * PLAYER_MOVE_SPEED * -1;
+		delta->y += info->player->plane.y * PLAYER_MOVE_SPEED * -1;
 	}
 	if (info->player->key.wasd[FT_NORTH])
 	{
-		delta->x += info->player->dir.x * PLAYER_SPEED;
-		delta->y += info->player->dir.y * PLAYER_SPEED;
+		delta->x += info->player->dir.x * PLAYER_MOVE_SPEED;
+		delta->y += info->player->dir.y * PLAYER_MOVE_SPEED;
 	}
 	if (info->player->key.wasd[FT_SOUTH])
 	{
-		delta->x += info->player->dir.x * PLAYER_SPEED * -1;
-		delta->y += info->player->dir.y * PLAYER_SPEED * -1;
+		delta->x += info->player->dir.x * PLAYER_MOVE_SPEED * -1;
+		delta->y += info->player->dir.y * PLAYER_MOVE_SPEED * -1;
 	}
 }
 
@@ -89,6 +89,6 @@ void	set_player_position(t_info *info)
 	delta.x = 0;
 	delta.y = 0;
 	get_amount_to_move(info, &delta);
-	rotate_vector(info->player, info->player->key.arrow);
 	move_player(info, &delta);
+	rotate_vector(info->player, info->player->key.arrow);
 }

--- a/srcs/mlx/draw.c
+++ b/srcs/mlx/draw.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/04 16:25:08 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/05 16:17:21 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/06 11:30:35 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,10 +67,11 @@ static void	draw_ceiling_floor(t_img *img, t_map *map)
 	}
 }
 
-void	draw_frame(t_info *info)
+int	draw_frame(t_info *info)
 {
 	set_player_position(info);
 	draw_ceiling_floor(info->img, info->map);
 	draw_wall(info);
 	mlx_put_image_to_window(info->mlx, info->window, info->img->img, 0, 0);
+	return (0);
 }

--- a/srcs/mlx/keyhook.c
+++ b/srcs/mlx/keyhook.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/02 14:30:59 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/06 11:21:34 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/06 11:57:23 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,9 +28,9 @@ static int	move_player_position(int keycode, t_info *info, int value)
 static int	move_direction_vector(int keycode, t_info *info)
 {
 	if (keycode == KEY_LEFT)
-		info->player->key.arrow = -PLAYER_SPEED;
+		info->player->key.arrow = -PLAYER_ROTATE_SPEED;
 	if (keycode == KEY_RIGHT)
-		info->player->key.arrow = PLAYER_SPEED;
+		info->player->key.arrow = PLAYER_ROTATE_SPEED;
 	return (FT_TRUE);
 }
 

--- a/srcs/mlx/keyhook.c
+++ b/srcs/mlx/keyhook.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/02 14:30:59 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/04 13:59:05 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/06 11:21:34 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,11 +16,11 @@ static int	move_player_position(int keycode, t_info *info, int value)
 {
 	if (keycode == KEY_D)
 		info->player->key.wasd[FT_EAST] = value;
-	else if (keycode == KEY_A)
+	if (keycode == KEY_A)
 		info->player->key.wasd[FT_WEST] = value;
-	else if (keycode == KEY_S)
+	if (keycode == KEY_S)
 		info->player->key.wasd[FT_SOUTH] = value;
-	else if (keycode == KEY_W)
+	if (keycode == KEY_W)
 		info->player->key.wasd[FT_NORTH] = value;
 	return (FT_TRUE);
 }
@@ -29,7 +29,7 @@ static int	move_direction_vector(int keycode, t_info *info)
 {
 	if (keycode == KEY_LEFT)
 		info->player->key.arrow = -PLAYER_SPEED;
-	else if (keycode == KEY_RIGHT)
+	if (keycode == KEY_RIGHT)
 		info->player->key.arrow = PLAYER_SPEED;
 	return (FT_TRUE);
 }
@@ -38,9 +38,9 @@ int	key_down(int keycode, t_info *info)
 {
 	if (keycode == KEY_ESC)
 		exit_with_button_close(info);
-	else if (keycode == KEY_D || keycode == KEY_A || keycode == KEY_S || keycode == KEY_W)
+	if (keycode == KEY_D || keycode == KEY_A || keycode == KEY_S || keycode == KEY_W)
 		return (move_player_position(keycode, info, FT_TRUE));
-	else if (keycode == KEY_LEFT || keycode == KEY_RIGHT)
+	if (keycode == KEY_LEFT || keycode == KEY_RIGHT)
 		return (move_direction_vector(keycode, info));
 	return (FT_TRUE);
 }
@@ -49,9 +49,9 @@ int	key_up(int keycode, t_info *info)
 {
 	if (keycode == KEY_D || keycode == KEY_A || keycode == KEY_S || keycode == KEY_W)
 		return (move_player_position(keycode, info, FT_FALSE));
-	else if (keycode == KEY_LEFT)
+	if (keycode == KEY_LEFT)
 		info->player->key.arrow = 0;
-	else if (keycode == KEY_RIGHT)
+	if (keycode == KEY_RIGHT)
 		info->player->key.arrow = 0;
 	return (FT_TRUE);
 }


### PR DESCRIPTION
- W, A, S, D 키를 눌러도 플레이어가 움직이지 않는 문제 해결
    - is_available_to_move() 의 하위 함수 is_edge() 에서 마지막 반환값을 false 로 바꾸어 해결
- 왼쪽, 오른쪽 화살표 키를 눌러도 플레이어가 회전하지 않는 문제 해결
    - 화살표 키가 눌리는 이벤트 발생 시 arrow 변수에 PLAYER_SPEED 를 저장하고 있었는데, 이것이 0.xxx 정도의 크기 밖에 안 되는 값이어서 rotate_vector() 에 들어가면 각도가 int 캐스팅 되면 0 이 되어 버려 회전을 하지 않는 것이었음
    - 따라서 플레이어 이동 시에 필요한 PLAYER_MOVE_SPEED 와 플레이어 회전 시에 필요한 PLAYER_ROTATE_SPEED 를 분리
- 플레이어의 위치나 방향 벡터가 변함에 따라 업데이트 해주는 set_player_postion() 함수가 한 번만 실행되는 문제 해결
    - mlx_loop_hook() 에서 draw_frame() 함수를 루프가 돌 때마다 호출하도록 변경
    - 이를 위하여 draw_frame() 의 반환값을 void 에서 int 로 변경