### PR TITLE
fix: Let player available to move when next position is in the same tile where present position is (#40)

### DIFF
--- a/maps/mini.cub
+++ b/maps/mini.cub
@@ -1,0 +1,13 @@
+NO ./textures/blue.xpm
+SO ./textures/green.xpm
+WE ./textures/cream.xpm
+EA ./textures/grey.xpm
+
+F 0,255,0
+C 0,0,255
+
+11111
+10001
+10N01
+10001
+11111

--- a/srcs/dda/set.c
+++ b/srcs/dda/set.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   preprocess.c                                       :+:      :+:    :+:   */
+/*   set.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/05 13:46:13 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/05 14:19:55 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/07 12:31:12 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,8 +19,8 @@ void	set_dda(t_dda *dda, t_player *player, double w)
 	dda->ray_dir_y = player->dir.y + player->plane.y * dda->camera_x;
 	dda->map_x = (int)player->pos.x;
 	dda->map_y = (int)player->pos.y;
-	dda->delta_dist_x = fabs(1 / dda->ray_dir_x);;
-	dda->delta_dist_y = fabs(1 / dda->ray_dir_y);;
+	dda->delta_dist_x = fabs(1 / dda->ray_dir_x);
+	dda->delta_dist_y = fabs(1 / dda->ray_dir_y);
 	dda->step_x = 1;
 	dda->step_y = 1;
 	if (dda->ray_dir_x < 0)
@@ -29,13 +29,13 @@ void	set_dda(t_dda *dda, t_player *player, double w)
 		dda->side_dist_x = (player->pos.x - dda->map_x) * dda->delta_dist_x;
 	}
 	else
-		dda->side_dist_x = (player->pos.x - dda->map_x + 1) * dda->delta_dist_x;
+		dda->side_dist_x = (dda->map_x + 1 - player->pos.x) * dda->delta_dist_x;
 	if (dda->ray_dir_y < 0)
 	{
 		dda->step_y = -1;
 		dda->side_dist_y = (player->pos.y - dda->map_y) * dda->delta_dist_y;
 	}
 	else
-		dda->side_dist_y = (player->pos.y - dda->map_y + 1) * dda->delta_dist_y;
+		dda->side_dist_y = (dda->map_y + 1 - player->pos.y) * dda->delta_dist_y;
 	dda->is_hit = FT_FALSE;
 }

--- a/srcs/map/player.c
+++ b/srcs/map/player.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/04 13:59:45 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/07 12:15:37 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/07 12:43:28 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,8 @@ static bool	is_edge(char **map, t_player *player, t_vector *next)
 
 	x = (int)next->x;
 	y = (int)next->y;
+	if (x == (int)player->pos.x && y == (int)player->pos.y)
+		return (FT_FALSE);
 	if (player->dir.x < 0 && player->dir.y < 0)
 		return (map[y + 1][x] == '1' && map[y][x + 1] == '1');
 	else if (player->dir.x > 0 && player->dir.y < 0)

--- a/srcs/map/player.c
+++ b/srcs/map/player.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/04 13:59:45 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/06 11:58:02 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/07 12:15:37 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,9 +32,9 @@ static bool	is_edge(char **map, t_player *player, t_vector *next)
 
 static bool	is_available_to_move(t_map *map, t_player *player, t_vector *next)
 {
-	if (next->x < 0 || next->x >= map->width)
+	if (next->x <= 0 || next->x >= map->width - 1)
 		return (FT_FALSE);
-	if (next->y < 0 || next->y >= map->height)
+	if (next->y <= 0 || next->y >= map->height - 1)
 		return (FT_FALSE);
 	if (map->map[(int)next->y][(int)next->x] == '1')
 		return (FT_FALSE);


### PR DESCRIPTION
- 플레이어가 움직이려는 위치와 현재 위치가 같은 타일 안에 존재할 경우, is_edge() 함수로 인해 막히지 않게 처리
- set_dda() 안에서 side_dist_x 와 side_dist_y 의 초기값이 잘못 설정된 것을 수정
- is_available_to_move() 에서 next 의 x, y 좌표값이 0 이거나 width - 1, height - 1 과 같은 경우도 false 처리
- mini.cub 샘플 맵파일 추가