### PR TITLE
fix: Fix calc_rotated_vector() (#52)

### DIFF
--- a/srcs/math/rotate.c
+++ b/srcs/math/rotate.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/02 18:03:24 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/04 15:02:54 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/07 13:15:19 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,10 +14,14 @@
 
 static void	calc_rotated_vector(t_vector *vector, int angle)
 {
+	t_vector	tmp;
+
 	if (!angle)
 		return ;
-	vector->x = vector->x * cos(angle * M_PI / 180) - vector->y * sin(angle * M_PI / 180);
-	vector->y = vector->x * sin(angle * M_PI / 180) + vector->y * cos(angle * M_PI / 180);
+	tmp.x = vector->x;
+	tmp.y = vector->y;
+	vector->x = tmp.x * cos(angle * M_PI / 180) - tmp.y * sin(angle * M_PI / 180);
+	vector->y = tmp.x * sin(angle * M_PI / 180) + tmp.y * cos(angle * M_PI / 180);
 }
 
 void	rotate_vector(t_player *player, int angle)


### PR DESCRIPTION
- 플레이어 초기 스폰이 'W' 또는 'E' 일 때 방향벡터의 y 값이 0 이 아닌 다른 값으로 설정되는 오류 수정
    - calc_rotated_vector() 에서 기존의 x, y 를 저장할 tmp 벡터 구조체를 추가함으로써 해결  