### PR TITLE
fix: Fix wall rendering error

### DIFF
--- a/srcs/mlx/texture.c
+++ b/srcs/mlx/texture.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/08 12:29:13 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/08 13:52:46 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/09 11:40:02 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,5 +47,5 @@ void	calc_texture_offset(t_info *info, t_dda *dda, t_texture *tex, int *start, i
     else if (dda->hit_side == HIT_Y && dda->ray_dir_y < 0)
 		tex->x = TEXTURE_WIDTH - tex->x - 1;
 	tex->step = 1.0 * TEXTURE_HEIGHT / line_height;
-	tex->pos = (*start - WINDOW_WIDTH / 2 + line_height / 2) * tex->step;
+	tex->pos = (*start - WINDOW_HEIGHT / 2 + line_height / 2) * tex->step;
 }


### PR DESCRIPTION
- 플레이어가 움직이면 벽의 텍스처 이미지도 함께 움직이는 오류가 있었음
- calc_texture_offset() 에서 tex_pos 를 구하는 과정에서 WINDOW_WIDTH 대신 WINDOW_HEIGHT 로 수정함으로써 해결 