### PR TITLE
fix: Fix error in case map contains undefined letter (#58)

### DIFF
--- a/srcs/map/check.c
+++ b/srcs/map/check.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/30 13:15:55 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/01 15:14:28 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/09 16:06:05 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,12 @@ static void	check_preconditions(t_map *map, t_info *info, char *line)
 	info->map->flag = FT_TRUE;
 }
 
+static void	check_undefined_letter(t_info *info, char *line, int i)
+{
+	if (!ft_strchr(" EWSN01", line[i]))
+		exit_with_free_all("Invalid map contents.", line, info);
+}
+
 static void	make_map(t_info *info, char *line)
 {
 	int	i;
@@ -39,12 +45,14 @@ static void	make_map(t_info *info, char *line)
 	i = 0;
 	while (line[i])
 	{
-		if (!ft_strchr(" EWSN01", line[i]))
-			exit_with_free_all("Invalid map contents.", line, info);
+		check_undefined_letter(info, line, i);
 		check_preconditions(info->map, info, line);
 		i = 0;
 		while (line[i])
+		{
+			check_undefined_letter(info, line, i);
 			i++;
+		}
 		if (i > info->map->width)
 			info->map->width = i;
 		info->map->tmp = ft_strjoin_free(info->map->tmp, line, 'L');

--- a/srcs/map/identifier.c
+++ b/srcs/map/identifier.c
@@ -6,7 +6,7 @@
 /*   By: sokim <sokim@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/30 16:22:14 by sokim             #+#    #+#             */
-/*   Updated: 2022/09/01 14:54:52 by sokim            ###   ########.fr       */
+/*   Updated: 2022/09/09 15:53:08 by sokim            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,8 +15,10 @@
 int	save_wall_texture(t_info *info, char *line)
 {
 	int	direction;
+	int	i;
 
 	direction = -1;
+	i = 3;
 	if (!ft_strncmp(line, "EA ", 3))
 		direction = FT_EAST;
 	else if (!ft_strncmp(line, "WE ", 3))
@@ -27,7 +29,9 @@ int	save_wall_texture(t_info *info, char *line)
 		direction = FT_NORTH;
 	if (info->map->tex_files[direction])
 		exit_with_free_all("Duplicated wall texture info.", line, info);
-	info->map->tex_files[direction] = ft_strdup(line + 3);
+	while (line[i] && line[i] == ' ')
+		i++;
+	info->map->tex_files[direction] = ft_strdup(line + i);
 	return (FT_TRUE);
 }
 


### PR DESCRIPTION
- 맵 컨텐츠에 " 01EWSN" 을 제외한 정의되지 않은 문자가 들어있는 경우 정상 작동하는 문제 해결
    - check_map_contents() 함수에서 각 행의 첫 번째 문자만 확인하고 나머지 문자들은 그대로 맵에 저장한 것이 문제였음
    - check_undefined_letter() 라는 함수를 만들어 모든 문자들을 확인하도록 하여 해결
- 맵 파일 내에서 각 요소들은 공백들로 구분될 수 있다고 하였으므로 공백을 스킵하는 코드 추가 